### PR TITLE
Made several modifications to ComBat to streamline the design matrix set...

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sva
 Title: Surrogate Variable Analysis
-Version: 3.13.1
+Version: 3.13.2
 Author: Jeffrey T. Leek <jtleek@gmail.com>, W. Evan Johnson <wej@bu.edu>,
     Hilary S. Parker <hiparker@jhsph.edu>, Elana J. Fertig <ejfertig@jhmi.edu>,
     Andrew E. Jaffe <ajaffe@jhsph.edu>, John D. Storey <jstorey@princeton.edu>

--- a/R/helper.R
+++ b/R/helper.R
@@ -49,62 +49,6 @@ edge.lfdr <- function(p, trunc=TRUE, monotone=TRUE, transf=c("probit", "logit"),
 
 
 
-
-
-
-# filters data based on presence/absence call
-filter.absent <- function(x,pct){
-	present <- T
-	col <- length(x)/2
-	pct.absent <- (sum(x[2*(1:col)]=="A") + sum(x[2*(1:col)]=="M"))/col
-	if(pct.absent > pct){present <- F}
-	present
-	}
-
-# Next two functions make the design matrix (X) from the sample info file 
-build.design <- function(vec, des=NULL, start=2){
-	tmp <- matrix(0,length(vec),nlevels(vec)-start+1)
-	for (i in 1:ncol(tmp)){tmp[,i] <- vec==levels(vec)[i+start-1]}
-	cbind(des,tmp)
-	}
-
-design.mat <- function(mod, numCov){
-
-	tmp <- which(colnames(mod) == 'Batch')
-	tmp1 <- as.factor(mod[,tmp])
-	cat("Found",nlevels(tmp1),'batches\n')
-	design <- build.design(tmp1,start=1)
-
-	if(!is.null(numCov)) {
-		theNumCov = as.matrix(mod[,numCov])
-		mod0 = as.matrix(mod[,-c(numCov,tmp)])
-	} else 	mod0 = as.matrix(mod[,-tmp])
-
-	ncov <- ncol(mod0)
-	
-	cat("Found",ncov,' categorical covariate(s)\n')
-	if(!is.null(numCov)) cat("Found",ncol(theNumCov),' continuous covariate(s)\n')
-	if(ncov>0){
-		for (j in 1:ncov){
-			tmp1 <- as.factor(as.matrix(mod0)[,j])
-			design <- build.design(tmp1,des=design)
-			}
-		}
-	if(!is.null(numCov)) design = cbind(design,theNumCov)
-	return(design)
-
-}
-
-
-
-# Makes a list with elements pointing to which array belongs to which batch
-list.batch <- function(mod){
-	tmp1 <- as.factor(mod[,which(colnames(mod) == 'Batch')])
-	batches <- NULL
-	for (i in 1:nlevels(tmp1)){batches <- append(batches, list((1:length(tmp1))[tmp1==levels(tmp1)[i]]))}
-	batches
-	}
-
 # Trims the data of extra columns, note your array names cannot be named 'X' or start with 'X.'
 trim.dat <- function(dat){
 	tmp <- strsplit(colnames(dat),'\\.')

--- a/man/ComBat.Rd
+++ b/man/ComBat.Rd
@@ -3,17 +3,15 @@
 \alias{ComBat}
 \title{Adjust for batch effects using an empirical Bayes framework}
 \usage{
-ComBat(dat, batch, mod, numCovs = NULL, par.prior = TRUE,
+ComBat(dat, batch, mod=NULL, par.prior = TRUE,
   prior.plots = FALSE)
 }
 \arguments{
 \item{dat}{Genomic measure matrix (dimensions probe x sample) - for example, expression matrix}
 
-\item{batch}{{Batch covariate (multiple batches allowed)}}
+\item{batch}{{Batch covariate (multiple batches are not allowed)}}
 
 \item{mod}{Model matrix for outcome of interest and other covariates besides batch}
-
-\item{numCovs}{The column numbers of the variables in mod to be treated as continuous variables (otherwise all covariates are treated as factors)}
 
 \item{par.prior}{(Optional) TRUE indicates parametric adjustments will be used, FALSE indicates non-parametric adjustments will be used}
 

--- a/vignettes/sva.Rnw
+++ b/vignettes/sva.Rnw
@@ -149,18 +149,18 @@ The \Rfunction{ComBat} function adjusts for known batches using an empirical Bay
 batch = pheno$batch
 @
 
-Just as with \Rfunction{sva}, we then need to create a model matrix for the adjustment variables, but do not include the variable of interest. Note that you do not include batch in creating this model matrix - it will be included later in \Rfunction{ComBat} function. In this case there are no other adjustment variables so we simply fit an intercept term.
+Just as with \Rfunction{sva}, we then need to create a model matrix for the adjustment variables, including the variable of interest. Note that you do not include batch in creating this model matrix - it will be included later in the \Rfunction{ComBat} function. In this case there are no other adjustment variables so we simply fit an intercept term.
 
 <<input>>=
 modcombat = model.matrix(~1, data=pheno)
 @
 
-By default, all adjustment variables will be treated as factor variables by the \Rfunction{ComBat} function.  If you would like to include continuous adjustment variables, also create a vector containing the column numbers of the continuous covariates in the model matrix.  This vector must then be input into \Rfunction{ComBat} via the \texttt{numCovs} option.
+Note that adjustment variables will be treated as given to the \Rfunction{ComBat} function.  This means if you are trying to adjust for a categorical variable with p different levels, you will need to give \Rfunction{ComBat} p-1 indicator variables for this covariate. We recommend using the \Rfunction{model.matrix} function to set these up. For continuous adjustment variables, just give a vector in the containing the covariate values in a single column of the model matrix.
 
 We now apply the \Rfunction{ComBat} function to the data, using parametric empirical Bayesian adjustments.
 
 <<input>>=
-combat_edata = ComBat(dat=edata, batch=batch, mod=modcombat, numCovs=NULL, par.prior=TRUE, prior.plots=FALSE)
+combat_edata = ComBat(dat=edata, batch=batch, mod=modcombat, par.prior=TRUE, prior.plots=FALSE)
 @
 
 This returns an expression matrix, with the same dimensions as your original dataset.  This new expression matrix has been adjusted for batch. Significance analysis can then be performed directly on the adjusted data using the model matrix and null model matrix as described before:


### PR DESCRIPTION
...up and to prepare for future modifications (mean-only batch adjustment, multiple batches, confounded designs, etc). More specifically, I did the following: (1) added a default value for the 'mod' parameter (mod=NULL), (2) removed the numCovs argument; the user is required to supply the covariate matrix, so distinguishing between categorical and numerical covariates is no longer necessary, (3) removed the dependancy on helper functions such as filter.absent (this is not currently used anyway), build.design, design.mat, list.batch, and (4) removed the statment that 'multiple batches are allowed'. This version of ComBat does not robustly handle multiple batches.