### PR TITLE
Added check for rows in input dat with no variance

### DIFF
--- a/R/ComBat.R
+++ b/R/ComBat.R
@@ -38,6 +38,10 @@
 #' 
 
 ComBat <- function(dat, batch, mod=NULL, par.prior=TRUE,prior.plots=FALSE,mean.only=FALSE,ref.batch=NULL) {
+  # check to make sure there are no rows in the data with zero variance
+  if (sum(apply(dat, 1, var) == 0) > 0) {
+    stop("One or more rows in the data found to have zero variance.")
+  }
   # make batch a factor and make a set of indicators for batch
   if(mean.only==TRUE){cat("Using the 'mean only' version of ComBat\n")}
   if(length(dim(batch))>1){stop("This version of ComBat only allows one batch variable")}  ## to be updated soon!


### PR DESCRIPTION
Currently ComBat fails when the input data matrix contains rows with no variance. There is likely a better solution for dealing with this, but for now at least, stopping execution with an informative error message may be useful.