### PR TITLE
Fixes for edge cases of n.sv <= 1

### DIFF
--- a/R/fsva.R
+++ b/R/fsva.R
@@ -71,15 +71,19 @@ fsva <- function(dbdat,mod,sv,newdat=NULL,method=c("fast","exact")){
       WX <- wts*dbdat
       svd.wx = svd(t(scale(t(WX),scale=FALSE)))
       D <- svd.wx$d[1:n.sv]
-      U <- svd.wx$u[,1:n.sv]
+      U <- svd.wx$u[,1:n.sv, drop=FALSE]
       P <- t(wts*t(1/D * t(U)))
       newV <- P %*% newdat
       sgn = rep(NA,n.sv)
       for(j in 1:sv$n.sv){
+        # This code should continue working with drop=FALSE since
+        # matrices are also vectors. Remove the else once there's no
+        # more concern about backward-compatibility with sva objects
+        # from previous versions.
         if(sv$n.sv>1){
           sgn[j] = sign(cor(svd.wx$v[1:ndb,j],sv$sv[1:ndb,j]))
         }
-        if(sv$n.sv==1){
+        else if(sv$n.sv==1){
           sgn[j] = sign(cor(svd.wx$v[1:ndb,j],sv$sv[1:ndb]))
         }
       }
@@ -97,10 +101,14 @@ fsva <- function(dbdat,mod,sv,newdat=NULL,method=c("fast","exact")){
         ss = svd(t(scale(t(tmpd),scale=FALSE)))
         sgn = rep(NA,sv$n.sv)
         for(j in 1:sv$n.sv){
+          # This code should continue working with drop=FALSE since
+          # matrices are also vectors. Remove the else once there's no
+          # more concern about backward-compatibility with sva objects
+          # from previous versions.
           if(sv$n.sv>1){
             sgn[j] = sign(cor(ss$v[1:ndb,j],sv$sv[1:ndb,j]))
           }
-          if(sv$n.sv==1){
+          else if(sv$n.sv==1){
             sgn[j] = sign(cor(ss$v[1:ndb,j],sv$sv[1:ndb]))
           }
         }

--- a/R/irwsva.build.R
+++ b/R/irwsva.build.R
@@ -68,7 +68,7 @@ irwsva.build <- function(dat, mod, mod0 = NULL,n.sv,B=5) {
     cat(paste(i," "))
   }
   
-  sv = svd(dats)$v[,1:n.sv]
+  sv = svd(dats)$v[,1:n.sv, drop=FALSE]
   retval <- list(sv=sv,pprob.gam = pprob.gam, pprob.b=pprob.b,n.sv=n.sv)
   return(retval)
   

--- a/R/ssva.R
+++ b/R/ssva.R
@@ -42,6 +42,6 @@ ssva <- function(dat,controls,n.sv){
   allZero = rowMeans(dats==0) == 1
   dats = dats[!allZero,]
   ss = svd((dats - rowMeans(dats)))
-  sv = ss$v[,1:n.sv]
+  sv = ss$v[,1:n.sv, drop=FALSE]
   return(list(sv=sv,pprob.gam = controls, pprob.b=NULL,n.sv=n.sv))
 }

--- a/R/ssva.R
+++ b/R/ssva.R
@@ -37,7 +37,13 @@ ssva <- function(dat,controls,n.sv){
   if(is.null(n.sv)){stop("ssva error: You must specify the number of surrogate variables")}
   if(dim(dat)[1] != length(controls)){stop("ssva error: You must specify a control vector the same length as the number of genes.")}
   if(any(controls > 1) | any(controls < 0)){stop("ssva error: Control probabilities must be between 0 and 1.")}
-  
+
+  if (n.sv == 0) {
+    warning("Returning zero surrogate variables as requested")
+    return(list(sv=matrix(nrow=ncol(dat), ncol=0),
+                pprob.gam = controls, pprob.b=NULL, n.sv=0))
+  }
+
   dats <- dat*controls
   allZero = rowMeans(dats==0) == 1
   dats = dats[!allZero,]

--- a/R/sva.R
+++ b/R/sva.R
@@ -51,7 +51,13 @@ sva <- function(dat, mod, mod0 = NULL,n.sv=NULL,controls=NULL,method=c("irw","tw
     ind = which(rank(-tmpv) <= vfilter)
     dat = dat[ind,]
   }
-  
+
+  if (!is.null(n.sv) && n.sv == 0) {
+    warning("Returning zero surrogate variables as requested")
+    return(list(sv=matrix(nrow=ncol(dat), ncol=0),
+                pprob.gam = rep(0, nrow(dat)), pprob.b=NULL, n.sv=0))
+  }
+
   if(is.null(n.sv)){
     n.sv = num.sv(dat,mod,method=numSVmethod,vfilter=vfilter)
   }
@@ -69,7 +75,9 @@ sva <- function(dat, mod, mod0 = NULL,n.sv=NULL,controls=NULL,method=c("irw","tw
       return(ssva(dat,controls,n.sv))
     }
   }else{
-    cat("No significant surrogate variables\n"); return(list(sv=0,pprob.gam=0,pprob.b=0,n.sv=0))
+    cat("No significant surrogate variables\n");
+    return(list(sv=matrix(nrow=ncol(dat), ncol=0),
+                pprob.gam = rep(0, nrow(dat)), pprob.b=NULL, n.sv=0))
   }
 
 }

--- a/R/twostepsva.build.R
+++ b/R/twostepsva.build.R
@@ -41,7 +41,7 @@ twostepsva.build <- function(dat, mod, n.sv){
   uu <- svd(res)
   ndf <- n - ceiling(sum(diag(H)))
   dstat <-  uu$d[1:ndf]^2/sum(uu$d[1:ndf]^2)
-  res.sv <- as.matrix(uu$v[,1:n.sv])
+  res.sv <- uu$v[,1:n.sv, drop=FALSE]
   
   use.var <- matrix(rep(FALSE, n.sv*m), ncol=n.sv)
   pp <- matrix(rep(FALSE, n.sv*m), ncol=n.sv)


### PR DESCRIPTION
I've done my best to root out all edge cases relating to n.sv being 1 or 0. For 1 SV, all sva variants should now return a 1-column matrix of surrogate variables rather than a numeric vector. For 0 SV, they should return a 0-column matrix of surrogate variables, a pprob.gam of all zeros (except for ssva, where pprob.gam = controls), a pprob.B of NULL, and n.sv = 0.

A test should probably be added running all the sva variants with 0, 1, and 2 or more SVs and assertting that the SVs are always returned in a matrix.